### PR TITLE
Remove TaskUUID from alert output

### DIFF
--- a/sentry/issue_alerts.go
+++ b/sentry/issue_alerts.go
@@ -24,7 +24,7 @@ type IssueAlert struct {
 	CreatedBy   *IssueAlertCreatedBy     `json:"createdBy,omitempty"`
 	Environment *string                  `json:"environment,omitempty"`
 	Projects    []string                 `json:"projects,omitempty"`
-	TaskUUID    *string                  `json:"uuid",omitempty` // This is actually the UUID of the async task that can be spawned to create the rule
+	TaskUUID    *string                  `json:"uuid,omitempty"` // This is actually the UUID of the async task that can be spawned to create the rule
 }
 
 // IssueAlertCreatedBy for defining the rule creator.
@@ -109,6 +109,7 @@ func (s *IssueAlertsService) Create(ctx context.Context, organizationSlug string
 		}
 	}
 
+	// Remove task UUID as it's no longer needed, otherwise it will end up in the JSON output.
 	alert.TaskUUID = nil
 	return alert, resp, nil
 }

--- a/sentry/issue_alerts.go
+++ b/sentry/issue_alerts.go
@@ -24,7 +24,7 @@ type IssueAlert struct {
 	CreatedBy   *IssueAlertCreatedBy     `json:"createdBy,omitempty"`
 	Environment *string                  `json:"environment,omitempty"`
 	Projects    []string                 `json:"projects,omitempty"`
-	TaskUUID    *string                  `json:"-"` // This is actually the UUID of the async task that can be spawned to create the rule
+	TaskUUID    *string                  `json:"uuid",omitempty` // This is actually the UUID of the async task that can be spawned to create the rule
 }
 
 // IssueAlertCreatedBy for defining the rule creator.
@@ -103,9 +103,15 @@ func (s *IssueAlertsService) Create(ctx context.Context, organizationSlug string
 			return nil, resp, errors.New("missing task uuid")
 		}
 		// We just received a reference to an async task, we need to check another endpoint to retrieve the issue alert we created
-		return s.getIssueAlertFromTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
+		alert, resp, err := s.getIssueAlertFromTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
+		if err != nil {
+			return nil, resp, err
+		}
+		alert.TaskUUID = nil
+		return alert, resp, nil
 	}
 
+	alert.TaskUUID = nil
 	return alert, resp, nil
 }
 

--- a/sentry/issue_alerts.go
+++ b/sentry/issue_alerts.go
@@ -103,12 +103,10 @@ func (s *IssueAlertsService) Create(ctx context.Context, organizationSlug string
 			return nil, resp, errors.New("missing task uuid")
 		}
 		// We just received a reference to an async task, we need to check another endpoint to retrieve the issue alert we created
-		alert, resp, err := s.getIssueAlertFromTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
+		alert, resp, err = s.getIssueAlertFromTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
 		if err != nil {
 			return nil, resp, err
 		}
-		alert.TaskUUID = nil
-		return alert, resp, nil
 	}
 
 	alert.TaskUUID = nil

--- a/sentry/issue_alerts.go
+++ b/sentry/issue_alerts.go
@@ -24,7 +24,7 @@ type IssueAlert struct {
 	CreatedBy   *IssueAlertCreatedBy     `json:"createdBy,omitempty"`
 	Environment *string                  `json:"environment,omitempty"`
 	Projects    []string                 `json:"projects,omitempty"`
-	TaskUUID    *string                  `json:"uuid,omitempty"` // This is actually the UUID of the async task that can be spawned to create the rule
+	TaskUUID    *string                  `json:"-"` // This is actually the UUID of the async task that can be spawned to create the rule
 }
 
 // IssueAlertCreatedBy for defining the rule creator.

--- a/sentry/metric_alerts.go
+++ b/sentry/metric_alerts.go
@@ -124,12 +124,10 @@ func (s *MetricAlertsService) Create(ctx context.Context, organizationSlug strin
 			return nil, resp, errors.New("missing task uuid")
 		}
 		// We just received a reference to an async task, we need to check another endpoint to retrieve the metric alert we created
-		alert, resp, err := s.getMetricAlertFromMetricAlertTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
+		alert, resp, err = s.getMetricAlertFromMetricAlertTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
 		if err != nil {
 			return nil, resp, err
 		}
-		alert.TaskUUID = nil
-		return alert, resp, nil
 	}
 
 	alert.TaskUUID = nil

--- a/sentry/metric_alerts.go
+++ b/sentry/metric_alerts.go
@@ -24,7 +24,7 @@ type MetricAlert struct {
 	Projects         []string              `json:"projects,omitempty"`
 	Owner            *string               `json:"owner,omitempty"`
 	DateCreated      *time.Time            `json:"dateCreated,omitempty"`
-	TaskUUID         *string               `json:"uuid,omitempty"` // This is actually the UUID of the async task that can be spawned to create the metric
+	TaskUUID         *string               `json:"-"` // This is actually the UUID of the async task that can be spawned to create the metric
 	// Don't `omitempty` because we want to set this to null to force Sentry to register this
 	// metric alert as a static alert when `ComparisonDelta` is empty.
 	// We type this as a float instead of an int because Sentry, server-side, returns a float for this value.

--- a/sentry/metric_alerts.go
+++ b/sentry/metric_alerts.go
@@ -130,6 +130,7 @@ func (s *MetricAlertsService) Create(ctx context.Context, organizationSlug strin
 		}
 	}
 
+	// Remove task UUID as it's no longer needed, otherwise it will end up in the JSON output.
 	alert.TaskUUID = nil
 	return alert, resp, nil
 }

--- a/sentry/metric_alerts.go
+++ b/sentry/metric_alerts.go
@@ -24,7 +24,7 @@ type MetricAlert struct {
 	Projects         []string              `json:"projects,omitempty"`
 	Owner            *string               `json:"owner,omitempty"`
 	DateCreated      *time.Time            `json:"dateCreated,omitempty"`
-	TaskUUID         *string               `json:"-"` // This is actually the UUID of the async task that can be spawned to create the metric
+	TaskUUID         *string               `json:"uuid,omitempty"` // This is actually the UUID of the async task that can be spawned to create the metric
 	// Don't `omitempty` because we want to set this to null to force Sentry to register this
 	// metric alert as a static alert when `ComparisonDelta` is empty.
 	// We type this as a float instead of an int because Sentry, server-side, returns a float for this value.
@@ -124,9 +124,15 @@ func (s *MetricAlertsService) Create(ctx context.Context, organizationSlug strin
 			return nil, resp, errors.New("missing task uuid")
 		}
 		// We just received a reference to an async task, we need to check another endpoint to retrieve the metric alert we created
-		return s.getMetricAlertFromMetricAlertTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
+		alert, resp, err := s.getMetricAlertFromMetricAlertTaskDetail(ctx, organizationSlug, projectSlug, *alert.TaskUUID)
+		if err != nil {
+			return nil, resp, err
+		}
+		alert.TaskUUID = nil
+		return alert, resp, nil
 	}
 
+	alert.TaskUUID = nil
 	return alert, resp, nil
 }
 


### PR DESCRIPTION
`uuid` field is causing permanent TF drift, failures to apply and is not required in the alert output.

Example: https://buildkite.com/canva-org/infra-apply-terraform/builds/170168

```
  # module.sentry_high_frequency_alert[0].sentry_issue_alert.default will be updated in-place
  ~ resource "sentry_issue_alert" "default" {
      ~ actions      = jsonencode(
          ~ [
              ~ {
                  ~ channel    = "edge-notifications" -> "#edge-notifications"
                    id         = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
                  ~ name       = "Send a notification to the Canva Slack workspace to edge-notifications (optionally, an ID: C021PEQFXGV) and show tags [] and notes  in notification" -> "Send a notification to the Canva Slack workspace to #edge-notifications (optionally, an ID: C021PEQFXGV) and show tags [] and notes  in notification"
                    tags       = ""
                  - uuid       = "7e1fecf2-bd58-4a8b-990c-c28a61bba5e9" -> null
                    # (3 unchanged elements hidden)
                },
            ]
        )
        id           = "14511763"
        name         = "High frequency of events(+500) in prod)"
        # (7 unchanged attributes hidden)
    }
```

Failure to apply:

```
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to
│ module.sentry_high_frequency_alert[0].sentry_issue_alert.default, provider
│ "provider[\"canva.com/infrastructure/sentry\"]" produced an unexpected new
│ value: .actions: was
│ cty.StringVal("[{\"channel\":\"#edge-notifications\",\"channel_id\":\"C021PEQFXGV\",\"id\":\"sentry.integrations.slack.notify_action.SlackNotifyServiceAction\",\"label\":\"Send
│ a slack notification\",\"name\":\"Send a notification to the Canva Slack
│ workspace to #edge-notifications (optionally, an ID: C021PEQFXGV) and show
│ tags [] and notes  in
│ notification\",\"tags\":\"\",\"workspace\":\"23762\"}]"), but now
│ cty.StringVal("[{\"channel\":\"edge-notifications\",\"channel_id\":\"C021PEQFXGV\",\"id\":\"sentry.integrations.slack.notify_action.SlackNotifyServiceAction\",\"label\":\"Send
│ a slack notification\",\"name\":\"Send a notification to the Canva Slack
│ workspace to edge-notifications (optionally, an ID: C021PEQFXGV) and show
│ tags [] and notes  in
│ notification\",\"tags\":\"\",\"uuid\":\"7e1fecf2-bd58-4a8b-990c-c28a61bba5e9\",\"workspace\":\"23762\"}]").
│
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
```